### PR TITLE
Support customizing read timeout and sleeps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ Done creating gpx, wrote 489333 bytes to track_2016_10_26__20_11_06.gpx.
 
 Deleting tracks is not necessary,the older tracks automatically get overwritten by the one currently being created. See [issue #1](../../issues/1) for a detailed explanation.
 
+### USB Timeouts & Raspberry Pi
+USB timeouts may occur when PyUSB is used with a Raspberry Pi, see [!5][!5] for more details. This issue appears to be mitigated by sleeping after large USB transfers. The following parameters are available to configure timeout and sleep behaviour:
+
+ - The read timeout, on commandline as `--read-timeout`, or `GPSPOD_READ_TIMEOUT` as environment variable (milliseconds). This specifies the timeout of each individual `.read()` call made to the USB device. This option only applies to PyUSB.
+ - The minimum size after which to sleep, on commandline as `--read-sleep-minsize`, or `GPSPOD_READ_SLEEP_MINSIZE` as environment variable (bytes). This specifies how large the USB transfer must have been to incur the sleep duration after this, if the read length exceeds this min size the execution will sleep for the duration. This affects both USB backends.
+ - The duration to sleep after exceeding the size criteria, on commandline as `--read-sleep-duration`, or `GPSPOD_READ_SLEEP_DURATION` as environment variable (milliseconds). This specifies how long the execution will sleep after a read which size exceeded the `read-sleep-minsize` value.
+
+These options can be set with environment flags to make it easier to always set them. On a Raspberry pi the following parameters were found (see [!6][!6]) to work well:
+```
+export GPSPOD_READ_SLEEP_MINSIZE=10000
+export GPSPOD_READ_SLEEP_DURATION=1000
+```
+
+On computers with a normal USB stack it is unlikely that modification of any of these parameters is necessary for correct behaviour.
+
+
 ## Development & Architecture
 For SUUNTO's watches, the [openambit][openambit] project provides an open-source alternative to Moveslink. However, this project does not support the GPS Pod. The [openambit][openambit] project provided me with a lot of information regarding the  communication protocol, hats off to them for their reverse-engineering work. There is a significant number of commands that is not shared with the ambit watches and the internal storage seems to be different as well.
 
@@ -100,3 +116,5 @@ Ambit, Movescount, Moveslink and Suunto are registered trademarks of Suunto Oy, 
 [debugpy]: gpspod/debug.py
 [mainpy]: gpspod/__main__.py
 [outputpy]: gpspod/output.py
+[!5]: https://github.com/iwanders/gps_track_pod/issues/5
+[!6]: https://github.com/iwanders/gps_track_pod/pull/6

--- a/gpspod/__main__.py
+++ b/gpspod/__main__.py
@@ -48,10 +48,12 @@ def get_communicator(args):
     if (args.fs is not None):
         return interact.OfflineCommunicator()
 
+    options = {"read_timeout": args.read_timeout, "read_sleep_minsize": args.read_sleep_minsize,
+               "read_sleep_duration": args.read_sleep_duration}
     if (args.record):
-        return interact.RecordingCommunicator(recordpath)
+        return interact.RecordingCommunicator(path=recordpath, **options)
     else:
-        return interact.Communicator()
+        return interact.Communicator(**options)
 
 
 def get_device(args, communicator):
@@ -452,6 +454,29 @@ parser.add_argument('--playbackfile', help="Play transactions from this file.",
 
 parser.add_argument('--fs', help="Specify a filesystem file to use.",
                     default=None)
+
+def retrieve_environment(key, vtype, default):
+    if os.environ.get(key):
+        value = vtype(os.environ.get(key))
+        return "{}=".format(key), value
+    else:
+        return "", vtype(default)
+
+read_timeout_str, read_timeout_val = retrieve_environment("GPSPOD_READ_TIMEOUT", float, 1000.0)
+parser.add_argument('--read-timeout', help="Timeout on raw USB byte reads. (environ GPSPOD_READ_TIMEOUT) [" +
+                    read_timeout_str + "%(default)s ms]", default=read_timeout_val, type=float)
+
+read_sleep_minsize_str, read_sleep_minsize_val = retrieve_environment("GPSPOD_READ_SLEEP_MINSIZE", float, float('inf'))
+parser.add_argument('--read-sleep-minsize',
+                    help="Sleep for a duration after receiving usb packet exceeding this size. "
+                         "(environ GPSPOD_READ_SLEEP_MINSIZE) [" + read_sleep_minsize_str + "%(default)s bytes]",
+                    default=read_sleep_minsize_val, type=float)
+
+read_sleep_duration_str, read_sleep_duration_val = retrieve_environment("GPSPOD_READ_SLEEP_DURATION", float, 0)
+parser.add_argument('--read-sleep-duration',
+                    help="Sleep for this duration after receiving usb packet exceeding a size. "
+                         "(environ GPSPOD_READ_SLEEP_DURATION) [" + read_sleep_duration_str + "%(default)s ms]",
+                    default=0, type=float)
 
 subparsers = parser.add_subparsers(dest="command")
 

--- a/gpspod/__main__.py
+++ b/gpspod/__main__.py
@@ -476,7 +476,7 @@ read_sleep_duration_str, read_sleep_duration_val = retrieve_environment("GPSPOD_
 parser.add_argument('--read-sleep-duration',
                     help="Sleep for this duration after receiving usb packet exceeding a size. "
                          "(environ GPSPOD_READ_SLEEP_DURATION) [" + read_sleep_duration_str + "%(default)s ms]",
-                    default=0, type=float)
+                    default=read_sleep_duration_val, type=float)
 
 subparsers = parser.add_subparsers(dest="command")
 


### PR DESCRIPTION
This should implement #5.

It adds:
- `--read-timeout`, a timeout on the pyUSB `.read()` call in milliseconds. Can be set through the environment flag `GPSPOD_READ_TIMEOUT`. (Add `export GPSPOD_READ_TIMEOUT=1000` to `.bashrc`).
- `--read-sleep-minsize`, if the packet exceeds this size the code will sleep for `read-sleep-duration`. In bytes, can be set through the environment flag `GPSPOD_READ_SLEEP_MINSIZE`.
- `--read-sleep-duration` The duration to sleep if the packet exceeded the minsize. Can be set through the environment flag `GPSPOD_READ_SLEEP_DURATION`), in milliseconds.

For the HIDAPI the following exports are required to preserve old behaviour.
```
export GPSPOD_READ_SLEEP_MINSIZE=0
export GPSPOD_READ_SLEEP_DURATION=0.1
```

@inancme you asked for this in #5, can you give it a go and experiment with which values work best on your Raspberry Pi? I'll add the values you recommend to the readme, detailing the issue on the raspberry pi and recommended values to overcome timeouts.